### PR TITLE
Update css for footer element

### DIFF
--- a/css/clf.drupal.css
+++ b/css/clf.drupal.css
@@ -101,6 +101,11 @@ textarea,
   clear: both;
 }
 
+/* Remove the overly-opinionated CLF footer style */
+footer {
+  background-color: inherit;
+}
+
 /**
  * @file
  * Override the CLF's alert styles.

--- a/sass/_clf.fixes.scss
+++ b/sass/_clf.fixes.scss
@@ -63,3 +63,8 @@ textarea,
 .form--inline .form-actions {
   clear: both;
 }
+
+/* Remove the overly-opinionated CLF footer style */
+footer {
+  background-color: inherit;
+}


### PR DESCRIPTION
The CLF assumes the background colour of a footer element is UBC blue, which is far too overreaching.