### PR TITLE
Wrap title and  node__meta in header region, remove footer element

### DIFF
--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -81,7 +81,7 @@
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
-  <header>
+
   {{ title_prefix }}
   {% if not page %}
     <h2{{ title_attributes }}>
@@ -99,7 +99,6 @@
       </div>
     </div>
   {% endif %}
-  </header>
 
   <div{{ content_attributes.addClass('node__content').addClass(contentClasses) }}>
     {{ content|without('links') }}

--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -81,7 +81,7 @@
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
-
+  <header>
   {{ title_prefix }}
   {% if not page %}
     <h2{{ title_attributes }}>
@@ -91,14 +91,15 @@
   {{ title_suffix }}
 
   {% if display_submitted %}
-    <footer class="node__meta">
+    <div class="node__meta">
       {{ author_picture }}
       <div{{ author_attributes.addClass('node__submitted') }}>
         {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
         {{ metadata }}
       </div>
-    </footer>
+    </div>
   {% endif %}
+  </header>
 
   <div{{ content_attributes.addClass('node__content').addClass(contentClasses) }}>
     {{ content|without('links') }}


### PR DESCRIPTION
The default classy node template inserts the node__meta into a footer element, and then adds this prior to the primary content. This seems counterintuitive and potentially poor usage.

I'm not sure this is a good way to solve this, but putting it out there for discussion.