### PR TITLE
Fix bug and simplify conditional class

### DIFF
--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -25,11 +25,7 @@
 {% macro menu_links(items, attributes, menu_level) %}
   {% import _self as menus %}
   {% if items %}
-    {% if menu_level == 0 %}
-      <ul{{ attributes.addClass('nav') }}>
-    {% else %}
-      <ul{{ attributes.addClass('dropdown-menu') }}>
-    {% endif %}
+    <ul{{ attributes.addClass(menu_level == 0 ? 'nav' : 'dropdown-menu') }}>
     {% for item in items %}
       {%
         set classes = [
@@ -52,7 +48,9 @@
       {% endif %}
       {% if item.below %}
         {{ menus.menu_links(item.below, attributes.removeClass('nav', 'navbar-nav'), menu_level + 1) }}
-      </div>
+      {% endif %}
+      {% if menu_level == 0 and item.is_expanded %}
+        </div>
       {% endif %}
     </li>
     {% endfor %}


### PR DESCRIPTION
Simplified the conditional that only toggles a class and moved the ending `</div>` tag inside a condition that would apply only when the opening `<div>` tag would  be created. 

It was breaking when printing more than 2 levels.