### PR TITLE
Made the toggling of sticky class relative to unit after discovering …

### DIFF
--- a/js/navigation.sticky.js
+++ b/js/navigation.sticky.js
@@ -25,20 +25,17 @@
         ticking = false;
         var currentScrollY = latestKnownScrollY;
 
-        //toggle classes
-        if (currentScrollY >= stickynav) {
+        // Toggle classes
+        if (currentScrollY > stickyunit) {
+          unitbar.classList.add("navigation-is-sticky");
+          document.body.classList.add("unit-area-is-sticky");
           navbar.classList.add("navigation-is-sticky");
           document.body.classList.add("unit-menu-is-sticky");
         } else {
-          navbar.classList.remove("navigation-is-sticky");
-          document.body.classList.remove("unit-menu-is-sticky");
-        };
-        if (currentScrollY >= stickyunit) {
-          unitbar.classList.add("navigation-is-sticky");
-          document.body.classList.add("unit-area-is-sticky");
-        } else {
           unitbar.classList.remove("navigation-is-sticky");
           document.body.classList.remove("unit-area-is-sticky");
+          navbar.classList.remove("navigation-is-sticky");
+          document.body.classList.remove("unit-menu-is-sticky");
         }
 
       }


### PR DESCRIPTION
…that Views pagination can pin the sticknav to the top under certain conditions. 

Steps to reproduce the sticky misbehaviour I was seeing:
 
Fresh D9
Composer require Galactus
Install CLF child manually and enable sticky nav
Generate some content
Create a Views page (paginated, Ajax-enabled, an exposed filter of any kind, enough content in the Global header that you need to scroll down to the filter)
Visit the Views page
Scroll down to filter (nav is sticky)
Click Apply on the filter
Scroll to top of page (nav is still in sticky state)
 
As admin, the result is that the sticky nav is under the admin_toolbar so it looks like it’s gone. As anon, it’s stuck at the top.
 
Same behaviour when you scroll down and click the pager.