### PR TITLE
Fixes issue #59: Main menu links are expanded even when their childre…

### DIFF
--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -41,7 +41,9 @@
         <li{{ item.attributes.addClass(classes, 'expanded', 'dropdown').removeClass('menu-item') }}>
           <div class="btn-group">
             {{ link(item.title, item.url, item.attributes.addClass('btn')) }}
-            <button class="btn dropdown-toggle" data-toggle="dropdown"><span class="ubc7-arrow blue down-arrow"></span></button>
+            {% if item.below %}
+              <button class="btn dropdown-toggle" data-toggle="dropdown"><span class="ubc7-arrow blue down-arrow"></span></button>
+            {% endif %}
       {% else %}
         <li{{ item.attributes.addClass(classes, 'item').removeClass('menu-item') }}>
           {{ link(item.title, item.url, {'class': ['navbar-link']}) }}


### PR DESCRIPTION
Fixes issue #59: Main menu links are expanded even when their children are not accessible by current user.

James indicated he would implement this, but it has been a while, so this PR is a bump since this issue still exists in the latest Galactus based on starterkit. 

