### PR TITLE
Accessibility issues

### DIFF
--- a/css/clf.drupal.css
+++ b/css/clf.drupal.css
@@ -168,11 +168,9 @@ a.close:hover {
   border-color: #00162f;
 }
 
-/* updating ubc7-unit-navigation mobile trigger from an a tag to a button tag alters layout, so we need to reassert the styling - this could be in a better location and done without using !important by increasing the selector specificity */
-#ubc7-unit .btn-navbar {
-  height: 35px !important;
-  width: 45px !important;
-  box-sizing: border-box !important;
-  margin-top: 7px !important;
-  padding: 11px 13px !important;
+/* updating ubc7-unit-navigation mobile trigger from an a tag to a button tag alters layout, so we need to reassert the styling */
+#ubc7-unit .navbar .btn-navbar {
+  height: 35px;
+  width: 45px;
+  padding: 11px 13px;
 }

--- a/css/clf.drupal.css
+++ b/css/clf.drupal.css
@@ -167,3 +167,12 @@ a.close:hover {
   background-color: #324d6a;
   border-color: #00162f;
 }
+
+/* updating ubc7-unit-navigation mobile trigger from an a tag to a button tag alters layout, so we need to reassert the styling - this could be in a better location and done without using !important by increasing the selector specificity */
+#ubc7-unit .btn-navbar {
+  height: 35px !important;
+  width: 45px !important;
+  box-sizing: border-box !important;
+  margin-top: 7px !important;
+  padding: 11px 13px !important;
+}

--- a/galactus.theme
+++ b/galactus.theme
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\Form\ViewsForm;
+use Drupal\Core\Template\Attribute;
 
 /**
  * Implements hook_page_attachments_alter().
@@ -360,6 +361,16 @@ function galactus_preprocess_block(&$variables) {
  */
 function galactus_preprocess_menu(&$variables) {
   $variables['attributes']['class'][] = 'clearfix';
+  // Add an id to each link attribute
+  foreach ($variables['items'] as $key => &$item) {
+    // Ensure we have an Attribute object.
+    if (!isset($item['attributes']) || !($item['attributes'] instanceof Attribute)) {
+      $item['attributes'] = new Attribute();
+    }
+    // Create a short stable hash based on the menu link key.
+    $key_hash = hash('crc32b', $key);
+    $item['attributes']->setAttribute('id', $key_hash);
+  }
 }
 
 /**

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -114,7 +114,7 @@
           {% endif %}
         </div>
         <div id="ubc7-global-utility">
-          <button type="button" data-toggle="collapse" data-target="#ubc7-global-menu"><span>UBC Search</span></button>
+          <button type="button" data-toggle="collapse" data-target="#ubc7-global-menu" aria-label="UBC Search toggle" aria-controls="ubc7-global-menu"><span>UBC Search</span></button>
           <noscript><a id="ubc7-global-utility-no-script" href="http://www.ubc.ca/">UBC Search</a></noscript>
         </div>
       </div>
@@ -132,11 +132,11 @@
         <!-- Mobile Menu Icon -->
         <div class="navbar">
         <!-- TODO: -->
-          <a class="btn btn-navbar drawer-toggle--primary" data-toggle="collapse" data-target="#ubc7-unit-navigation">
+          <button class="btn btn-navbar drawer-toggle--primary" data-toggle="collapse" data-target="#ubc7-unit-navigation" aria-label="Mobile menu toggle" aria-controls="ubc7-unit-navigation" type="button">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
-          </a>
+          </button>
         </div>
         <div id="ubc7-unit-name"{{ faculty_option != '' ? ' class="ubc7-single-element"' }}>
           <a href="{{ base_path }}">

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -20,7 +20,7 @@
 #}
 {{ menus.menu_links(items, attributes, 0) }}
 
-{% macro menu_links(items, attributes, menu_level) %}
+{% macro menu_links(items, attributes, menu_level, menuid) %}
   {% import _self as menus %}
   {% if items %}
     <ul{{ attributes.addClass(menu_level == 0 ? 'nav' : 'dropdown-menu') }}>
@@ -36,18 +36,19 @@
         ]
       %}
       {% if menu_level == 0 and item.is_expanded %}
+        {% set menuid = item.attributes.id %}
         <li{{ item.attributes.addClass(classes, 'expanded', 'dropdown').removeClass('menu-item') }}>
           <div class="btn-group">
             {{ link(item.title, item.url, item.attributes.addClass('btn')) }}
             {% if item.below %}
-              <button class="btn dropdown-toggle" data-toggle="dropdown"><span class="ubc7-arrow blue down-arrow"></span></button>
+              <button class="btn dropdown-toggle" data-toggle="dropdown" aria-label="Toggle submenu for {{ item.title }}" aria-expanded="false" aria-haspopup="true" aria-controls="menu-id-{{ menuid }}"><span class="ubc7-arrow blue down-arrow"></span></button>
             {% endif %}
       {% else %}
         <li{{ item.attributes.addClass(classes, 'item').removeClass('menu-item') }}>
           {{ link(item.title, item.url, {'class': ['navbar-link']}) }}
       {% endif %}
       {% if item.below %}
-        {{ menus.menu_links(item.below, attributes.removeClass('nav', 'navbar-nav'), menu_level + 1) }}
+        {{ menus.menu_links(item.below, attributes.removeClass('nav', 'navbar-nav').setAttribute('id', 'menu-id-' ~ menuid), menu_level + 1) }}
       {% endif %}
       {% if menu_level == 0 and item.is_expanded %}
         </div>


### PR DESCRIPTION
We had an accessibility scan on EXL and the one very problematic finding was that the mobile navigation trigger wasn't functional when navigating via keyboard (keyboard access was likely only ever tested in a desktop context).

This isn't a Galactus-specific issue, it's a CLF-wide issue.

Changing the `a` tag to a `button` allows for correct focus and function of the trigger. While this could also be done with just aria, I think using the `a` tag here is less correct; there is no link to another location, it's a trigger.

The unfortunte consequence of changing the element is that the styles need to be updated as well. I've added these in the `clf.drupal.css ` file, but I'm sure it could have a better home.

I've also added the` aria-controls` and `aria-label` attributes to improve screenreader feedback on the two collapsible regions in the header.

There's more to do, but this seems to be low-hanging fruit.

