### PR TITLE
Add DDEV Drupal Contrib for ease-of-maintenance

### DIFF
--- a/.ddev/addon-metadata/ddev-drupal-contrib/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-drupal-contrib/manifest.yaml
@@ -1,0 +1,19 @@
+name: ddev-drupal-contrib
+repository: ddev/ddev-drupal-contrib
+version: 1.1.3
+install_date: "2025-08-22T12:21:06-07:00"
+project_files:
+    - commands/host/core-version
+    - commands/web/eslint
+    - commands/web/expand-composer-json
+    - commands/web/nightwatch
+    - commands/web/phpcbf
+    - commands/web/phpcs
+    - commands/web/phpstan
+    - commands/web/phpunit
+    - commands/web/poser
+    - commands/web/stylelint
+    - commands/web/symlink-project
+    - config.contrib.yaml
+global_files: []
+removal_actions: []

--- a/.ddev/commands/host/core-version
+++ b/.ddev/commands/host/core-version
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Switch the core version and rebuild.
+## Usage: core-version [version]
+## Example: "ddev core-version ^11" or "ddev core-version ~11.1.0"
+
+set -eu -o pipefail
+
+# Handle default values.
+DRUPAL_CORE=${1:-default}
+if [ "$DRUPAL_CORE" == "default" ]; then
+  DRUPAL_CORE=""
+fi
+
+# Set/clear the env.
+ddev dotenv set .ddev/.env.web --drupal-core "${DRUPAL_CORE}"
+
+# Restart and rebuild.
+ddev restart
+ddev poser

--- a/.ddev/commands/web/eslint
+++ b/.ddev/commands/web/eslint
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run eslint inside the web container
+## Usage: eslint [flags] [args]
+## Example: "ddev eslint"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+if "$DDEV_DOCROOT/core/node_modules/.bin/eslint" --version >/dev/null ; then
+  # Configure prettier
+  test -e .prettierrc.json || ln -s $DDEV_DOCROOT/core/.prettierrc.json .
+  test -e .prettierignore || echo '*.yml' > .prettierignore
+  # Change directory to the project root folder
+  cd "$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}" || exit
+  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/eslint" --config="../../../core/.eslintrc.passing.json" --no-error-on-unmatched-pattern --ignore-pattern="*.es6.js" --resolve-plugins-relative-to=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core --ext=.js,.yml . "$@"
+else
+  echo "eslint is not available. You may need to 'ddev exec \"cd $DDEV_DOCROOT/core && yarn install\"'"
+  exit 1
+fi

--- a/.ddev/commands/web/expand-composer-json
+++ b/.ddev/commands/web/expand-composer-json
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Add Drupal core and other needed dependencies.
+## Usage: expand-composer-json [flags] [PROJECT_NAME]
+## Example: "ddev expand-composer-json ctools"
+## ExecRaw: true
+## MutagenSync: true
+
+set -eu -o pipefail
+
+# Set the default core version.
+export DRUPAL_CORE=${DRUPAL_CORE:-^11}
+
+export _WEB_ROOT=$DDEV_DOCROOT
+cd "$DDEV_COMPOSER_ROOT" || exit
+curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/expand_composer_json.php
+_ddev_drupal_contrib_empty_composer=false
+if [[ ! -f composer.json ]]; then
+  echo "{}" > composer.json
+  _ddev_drupal_contrib_empty_composer=true
+fi
+php expand_composer_json.php "$DDEV_SITENAME"
+rm -f expand_composer_json.php
+if [ "$_ddev_drupal_contrib_empty_composer" = true ];  then
+  rm -f composer.json
+fi

--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: Install Drupal and enable the module
+## Usage: install
+## Example: "ddev install"
+
+vendor/bin/drush site:install --yes
+vendor/bin/drush theme:install galactus --yes
+vendor/bin/drush config:set system.theme default galactus --yes

--- a/.ddev/commands/web/nightwatch
+++ b/.ddev/commands/web/nightwatch
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run nightwatch inside the web container
+## Usage: nightwatch [flags] [args]
+## Example: "ddev nightwatch"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+yarn --cwd "$DDEV_DOCROOT/core" test:nightwatch  "$DDEV_APPROOT/$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/" "$@"

--- a/.ddev/commands/web/phpcbf
+++ b/.ddev/commands/web/phpcbf
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run phpcbf inside the web container
+## Usage: phpcbf [flags] [args]
+## Example: "ddev phpcbf" or "ddev phpcbf -n"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+if ! command -v phpcbf >/dev/null; then
+  echo "phpcbf is not available. You may need to 'ddev composer install'"
+  exit 1
+fi
+test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
+phpcbf -s --report-full --report-summary --report-source $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH "$@"

--- a/.ddev/commands/web/phpcs
+++ b/.ddev/commands/web/phpcs
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run phpcs inside the web container
+## Usage: phpcs [flags] [args]
+## Example: "ddev phpcs" or "ddev phpcs -n"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+if ! command -v phpcs >/dev/null; then
+  echo "phpcs is not available. You may need to 'ddev composer install'"
+  exit 1
+fi
+test -e phpcs.xml.dist || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpcs.xml.dist
+phpcs -s --report-full --report-summary --report-source $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH --ignore=*/.ddev/* "$@"

--- a/.ddev/commands/web/phpstan
+++ b/.ddev/commands/web/phpstan
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run phpstan inside the web container
+## Usage: phpstan [flags] [args]
+## Example: "ddev phpstan" or "ddev phpstan -n"
+## ExecRaw: true
+## MutagenSync: true
+
+set -eu -o pipefail
+
+if ! command -v phpstan >/dev/null; then
+  echo "phpstan is not available. You may need to 'ddev poser'"
+  exit 1
+fi
+test -e phpstan.neon || curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/assets/phpstan.neon
+# See https://git.drupalcode.org/project/gitlab_templates/-/commit/a107b7f1f79af12e0b09f70be47b68e3f69b4504
+sed -i 's/BASELINE_PLACEHOLDER/phpstan-baseline.neon/g' phpstan.neon
+# Add an empty baseline file to ensure it exists.
+test -e phpstan-baseline.neon || touch phpstan-baseline.neon
+
+EXTENSION_DIRECTORY=$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}
+cd "$EXTENSION_DIRECTORY" || exit 1
+# Ensure PHPStan configuration is symlinked from project root.
+ln -s $DDEV_DOCROOT/phpstan.neon 2>/dev/null || true
+ln -s $DDEV_DOCROOT/phpstan-baseline.neon 2>/dev/null || true
+phpstan analyze . "$@"

--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run phpunit inside the web container
+## Usage: phpunit [flags] [args]
+## Example: "ddev phpunit" or "ddev phpunit --stop-on-failure"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+if ! command -v phpunit >/dev/null; then
+  echo "phpunit is not available. You may need to 'ddev composer install'"
+  exit 1
+fi
+
+# CHECK for local config.
+if [ -f "phpunit.xml" ]; then
+    # Defer to local config
+    phpunit "$@"
+else
+    # Bootstrap Drupal tests and run all custom module tests.
+    phpunit --bootstrap $PWD/$DDEV_DOCROOT/core/tests/bootstrap.php $DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH "$@"
+fi

--- a/.ddev/commands/web/poser
+++ b/.ddev/commands/web/poser
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Expand composer.json and run composer install.
+## Usage: poser [flags] [args]
+## Example: "ddev poser" or "ddev poser --prefer-source"
+## ExecRaw: true
+## MutagenSync: true
+
+set -eu -o pipefail
+
+export COMPOSER=composer.contrib.json
+.ddev/commands/web/expand-composer-json
+composer install "$@"
+# The -f flag suppresses errors if lock file does not exist.
+rm -f composer.contrib.json composer.contrib.lock
+touch $DDEV_DOCROOT/core/.env

--- a/.ddev/commands/web/stylelint
+++ b/.ddev/commands/web/stylelint
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Run stylelint inside the web container
+## Usage: stylelint [flags] [args]
+## Example: "ddev stylelint"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+if $DDEV_DOCROOT/core/node_modules/.bin/stylelint --version >/dev/null ; then
+  # Change directory to the project root folder
+  cd "$DDEV_DOCROOT/$DRUPAL_PROJECTS_PATH/${DDEV_SITENAME//-/_}" || exit
+  "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/node_modules/.bin/stylelint" --color --config "$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT/core/.stylelintrc.json" "./**/*.css" "$@"
+else
+  echo "stylelint is not available. You may need to 'ddev exec \"cd $DDEV_DOCROOT/core && yarn install\"'"
+  exit 1
+fi

--- a/.ddev/commands/web/symlink-project
+++ b/.ddev/commands/web/symlink-project
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## Description: Symlink project files into the configured location (defaults to `web/modules/custom/[PROJECT_NAME]`)
+## Usage: symlink-project [flags] [args]
+## Example: "ddev symlink-project"
+## ExecRaw: true
+
+set -eu -o pipefail
+
+export _WEB_ROOT=$DDEV_DOCROOT
+#todo use more dynamic ref.
+cd "$DDEV_COMPOSER_ROOT" || exit
+curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php
+
+# Suppress a warning.
+PROJECT_FILES=$(ls -A --ignore="web" --ignore="vendor" --ignore="symlink_project.php" --ignore=".ddev" --ignore=".idea")
+export PROJECT_FILES
+# Symlink name using underscores.
+# @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
+php symlink_project.php "${DDEV_SITENAME//-/_}"
+rm -f symlink_project.php

--- a/.ddev/config.contrib.yaml
+++ b/.ddev/config.contrib.yaml
@@ -1,0 +1,24 @@
+#ddev-generated
+## Command provided by https://github.com/ddev/ddev-drupal-contrib
+## To customize this configuration, see:
+## https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/
+web_environment:
+  # To change the Drupal core version, see the README:
+  # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-drupal-core-version
+  # https://git.drupalcode.org/project/gitlab_templates/-/blob/1.9.6/scripts/expand_composer_json.php?ref_type=tags#L15
+  - IGNORE_PROJECT_DRUPAL_CORE_VERSION=1
+  # To change the location of your project code, see the README:
+  # https://github.com/ddev/ddev-drupal-contrib/blob/main/README.md#changing-the-symlink-location
+  - DRUPAL_PROJECTS_PATH=themes/custom
+  - SIMPLETEST_DB=mysql://db:db@db/db
+  - SIMPLETEST_BASE_URL=http://web
+  - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
+  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
+hooks:
+  post-start:
+    - exec-host: |
+        if [[ -f vendor/autoload.php ]]; then
+          ddev symlink-project
+        else
+          exit 0
+        fi

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,15 @@
+name: galactus
+type: drupal
+docroot: web
+php_version: "8.3"
+webserver_type: nginx-fpm
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+    type: mariadb
+    version: "10.11"
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+corepack_enable: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ node_modules
 
 # Development source maps.
 *.map
+
+# Visual Regression Testing
+test-results/
+playwright-report/
+
+# DDEV
+/recipes/
+/vendor/
+/web/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,16 @@ You may setup your local environment with [DDEV]. This project leverages the
     without needing to modify the root composer.json. Find out more in DDEV Drupal Contrib
     [commands].
 
-5.  Install Drupal and set the theme.
+4.  Symlink the theme into the `web/themes/custom` directory.
+
+        ddev symlink-project
+
+
+6.  Install Drupal and set the theme.
 
         ddev install
 
-6.  Visit site in browser.
+7.  Visit site in browser.
 
         ddev describe
 
@@ -34,7 +39,7 @@ You may setup your local environment with [DDEV]. This project leverages the
 
         ddev drush uli
 
-7.  Push work to Merge Requests (MRs) opened via this project's [issue queue].
+8.  Push work to Merge Requests (MRs) opened via this project's [issue queue].
 
 
 CHANGING DRUPAL CORE VERSION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+CONTRIBUTING
+------------
+
+You may setup your local environment with [DDEV]. This project leverages the
+[DDEV Drupal Contrib] plugin.
+
+1.  [Install DDEV] with a [Docker provider].
+2.  Clone this project's repository from Drupal's GitLab.
+
+        git clone git@github.com:ubc-web-services/galactus.git
+        cd galactus
+
+3.  Startup DDEV.
+
+        ddev start
+
+4.  Install composer dependencies.
+
+        ddev poser
+
+    Note: `ddev poser` is shorthand for `ddev composer` to add in Drupal core dependencies
+    without needing to modify the root composer.json. Find out more in DDEV Drupal Contrib
+    [commands].
+
+5.  Install Drupal and set the theme.
+
+        ddev install
+
+6.  Visit site in browser.
+
+        ddev describe
+
+    Or, login as user 1:
+
+        ddev drush uli
+
+7.  Push work to Merge Requests (MRs) opened via this project's [issue queue].
+
+
+CHANGING DRUPAL CORE VERSION
+----------------------------
+
+DDEV Drupal Contrib installs a recent stable version of Drupal core via the `DRUPAL_CORE`
+environment variable. Review .ddev/config.yaml to find the current default version.
+
+Override the current default version of Drupal core by creating .ddev/config.local.yaml:
+
+```yaml
+web_environment:
+    - DRUPAL_CORE=^10
+```
+
+UPDATING DEPENDENCIES
+---------------------
+
+This project depends on 3rd party PHP libraries. It also specifies suggested "dev dependencies"
+for contribution on local development environments. Occasionally, DDEV and DDEV Drupal Contrib
+must be updated as well.
+
+1.  Create an issue, MR, and checkout the MR branch.
+2.  Update DDEV and DDEV Drupal Contrib itself.
+
+    Read https://ddev.readthedocs.io/en/stable/users/install/ddev-upgrade/
+
+        ddev config --update
+        ddev get ddev/ddev-drupal-contrib
+        ddev restart
+        ddev poser
+        ddev symlink-project
+
+3.  Review and update PHP dependencies defined in composer.json
+
+        ddev composer outdated --direct
+
+3.  Test clean install, commit, and push.
+
+
+[DDEV]: https://www.ddev.com/
+[DDEV Drupal Contrib]: https://github.com/ddev/ddev-drupal-contrib
+[Install DDEV]: https://ddev.readthedocs.io/en/stable/
+[Docker provider]: https://ddev.readthedocs.io/en/stable/users/install/docker-installation/
+[issue queue]: https://github.com/ubc-web-services/galactus/issues
+[commands]: https://github.com/ddev/ddev-drupal-contrib#commands

--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,16 @@
     "name": "O'Toole, James",
     "email": "james.otoole@ubc.ca"
   }],
-  "require": {}
+  "require": {},
+    "require-dev": {
+        "drupal/coder": "^8.3.16",
+        "drush/drush": "^12.5 || ^13.3"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "tbachert/spi": false
+        }
+    }
 }


### PR DESCRIPTION
I've been maintaining my contrib projects using [https://github.com/ddev/ddev-drupal-contrib](https://github.com/ddev/ddev-drupal-contrib) for some time now, and have just been leaving the .ddev folder uncommitted.

But now that DDEV has become the gold standard for Drupal local development, I feel it is now safe to commit the .ddev folder to the project (as recommended by ddev-drupal-contrib) and then document in the CONTRIBUTING.md how to setup a local environment for contribution/maintenance.